### PR TITLE
Fix RTSP caps propagation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent Guidelines for splashscreen_rk
+
+- Maintain compatibility with GStreamer 1.14 when touching RTSP code. Avoid
+  using helpers that were introduced after 1.14 (for example,
+  `gst_rtsp_media_is_prepared`). Prefer querying existing object properties or
+  version guards when newer APIs are required.
+- When updating `src/` sources, keep diagnostic logging in the existing
+  `[rtsp]` format so deployments have consistent output.
+- Build and test with `make` when possible. If GStreamer development packages
+  are missing in the environment, record that limitation in the testing
+  section.

--- a/src/splashlib.c
+++ b/src/splashlib.c
@@ -295,6 +295,8 @@ static void on_media_configure(GstRTSPMediaFactory *factory, GstRTSPMedia *media
   g_signal_connect(media, "prepared", G_CALLBACK(on_media_prepared), s);
   g_signal_connect(media, "unprepared", G_CALLBACK(on_media_unprepared), s);
   g_printerr("[rtsp] media-configure\n");
+  if (gst_rtsp_media_is_prepared(media))
+    on_media_prepared(media, s);
 }
 
 // ------------------------------------------------------------------

--- a/src/splashlib.c
+++ b/src/splashlib.c
@@ -123,6 +123,17 @@ static void on_client_connected(GstRTSPServer *server, GstRTSPClient *client, gp
   g_signal_connect(client, "teardown-request", G_CALLBACK(on_req_teardown), user);
 }
 
+static gboolean media_is_prepared(GstRTSPMedia *media) {
+#ifdef GST_RTSP_MEDIA_STATUS_PREPARED
+  GstRTSPMediaStatus status = GST_RTSP_MEDIA_STATUS_UNPREPARED;
+  g_object_get(media, "status", &status, NULL);
+  return status >= GST_RTSP_MEDIA_STATUS_PREPARED;
+#else
+  (void)media;
+  return FALSE;
+#endif
+}
+
 static void on_media_prepared(GstRTSPMedia *media, Splash *s) {
   GstElement *bin = gst_rtsp_media_get_element(media);
   if (!bin) return;
@@ -295,7 +306,7 @@ static void on_media_configure(GstRTSPMediaFactory *factory, GstRTSPMedia *media
   g_signal_connect(media, "prepared", G_CALLBACK(on_media_prepared), s);
   g_signal_connect(media, "unprepared", G_CALLBACK(on_media_unprepared), s);
   g_printerr("[rtsp] media-configure\n");
-  if (gst_rtsp_media_is_prepared(media))
+  if (media_is_prepared(media))
     on_media_prepared(media, s);
 }
 

--- a/src/splashlib.c
+++ b/src/splashlib.c
@@ -44,7 +44,7 @@ struct Splash {
   // Sender (RTSP)
   GstRTSPServer *rtsp_server;
   GstRTSPMediaFactory *rtsp_factory;
-  GPtrArray *rtsp_appsrcs; // array of GstElement* (appsrc), owns refs
+  GstElement *appsrc_rtsp;
 
   GstCaps *current_caps;
 
@@ -115,45 +115,6 @@ static void on_client_connected(GstRTSPServer *server, GstRTSPClient *client, gp
   g_signal_connect(client, "teardown-request", G_CALLBACK(on_req_teardown), user);
 }
 
-static gboolean rtsp_track_appsrc_locked(Splash *s, GstElement *appsrc) {
-  if (!s->rtsp_appsrcs)
-    s->rtsp_appsrcs = g_ptr_array_new();
-
-  for (guint i = 0; i < s->rtsp_appsrcs->len; ++i) {
-    if (g_ptr_array_index(s->rtsp_appsrcs, i) == appsrc)
-      return FALSE;
-  }
-
-  g_ptr_array_add(s->rtsp_appsrcs, gst_object_ref(appsrc));
-  return TRUE;
-}
-
-static gboolean rtsp_untrack_appsrc_locked(Splash *s, GstElement *appsrc) {
-  if (!s->rtsp_appsrcs)
-    return FALSE;
-
-  for (guint i = 0; i < s->rtsp_appsrcs->len; ++i) {
-    GstElement *cur = g_ptr_array_index(s->rtsp_appsrcs, i);
-    if (cur == appsrc) {
-      g_ptr_array_remove_index_fast(s->rtsp_appsrcs, i);
-      gst_object_unref(cur);
-      return TRUE;
-    }
-  }
-  return FALSE;
-}
-
-static void rtsp_clear_appsrcs_locked(Splash *s) {
-  if (!s->rtsp_appsrcs)
-    return;
-
-  for (guint i = 0; i < s->rtsp_appsrcs->len; ++i) {
-    GstElement *cur = g_ptr_array_index(s->rtsp_appsrcs, i);
-    gst_object_unref(cur);
-  }
-  g_ptr_array_set_size(s->rtsp_appsrcs, 0);
-}
-
 static gboolean bind_media_appsrc(Splash *s, GstRTSPMedia *media, const char *tag) {
   GstElement *bin = gst_rtsp_media_get_element(media);
   if (!bin) {
@@ -171,13 +132,20 @@ static gboolean bind_media_appsrc(Splash *s, GstRTSPMedia *media, const char *ta
   g_object_set(appsrc, "is-live", TRUE, "format", GST_FORMAT_TIME,
                "block", TRUE, "do-timestamp", FALSE, NULL);
 
+  gboolean reused = FALSE;
   g_mutex_lock(&s->lock);
-  gboolean added = rtsp_track_appsrc_locked(s, appsrc);
+  if (s->appsrc_rtsp != appsrc) {
+    if (s->appsrc_rtsp)
+      gst_object_unref(s->appsrc_rtsp);
+    s->appsrc_rtsp = gst_object_ref(appsrc);
+  } else {
+    reused = TRUE;
+  }
   if (s->current_caps)
     gst_app_src_set_caps(GST_APP_SRC(appsrc), s->current_caps);
   g_mutex_unlock(&s->lock);
 
-  g_printerr("[rtsp] %s: appsrc %s\n", tag, added ? "ready" : "reused");
+  g_printerr("[rtsp] %s: appsrc %s\n", tag, reused ? "reused" : "ready");
   gst_object_unref(appsrc);
   return TRUE;
 }
@@ -198,7 +166,11 @@ static void on_media_unprepared(GstRTSPMedia *media, Splash *s) {
 
   gboolean removed = FALSE;
   g_mutex_lock(&s->lock);
-  removed = rtsp_untrack_appsrc_locked(s, appsrc);
+  if (s->appsrc_rtsp == appsrc) {
+    gst_object_unref(s->appsrc_rtsp);
+    s->appsrc_rtsp = NULL;
+    removed = TRUE;
+  }
   g_mutex_unlock(&s->lock);
 
   if (removed)
@@ -255,12 +227,8 @@ static GstFlowReturn on_new_sample(GstAppSink *sink, gpointer user) {
       s->current_caps = gst_caps_copy(caps);
       if (s->appsrc_udp)
         gst_app_src_set_caps(GST_APP_SRC(s->appsrc_udp), s->current_caps);
-      if (s->rtsp_appsrcs) {
-        for (guint i = 0; i < s->rtsp_appsrcs->len; ++i) {
-          GstElement *elem = g_ptr_array_index(s->rtsp_appsrcs, i);
-          gst_app_src_set_caps(GST_APP_SRC(elem), s->current_caps);
-        }
-      }
+      if (s->appsrc_rtsp)
+        gst_app_src_set_caps(GST_APP_SRC(s->appsrc_rtsp), s->current_caps);
     }
   }
 
@@ -269,23 +237,17 @@ static GstFlowReturn on_new_sample(GstAppSink *sink, gpointer user) {
   s->next_pts += s->dur;
 
   GstElement *udp_target = NULL;
-  GPtrArray *rtsp_targets = NULL;
+  GstElement *rtsp_target = NULL;
   if (s->out_mode == SPLASH_OUT_UDP) {
     if (s->appsrc_udp)
       udp_target = gst_object_ref(s->appsrc_udp);
-  } else if (s->rtsp_appsrcs && s->rtsp_appsrcs->len > 0) {
-    rtsp_targets = g_ptr_array_new_with_free_func((GDestroyNotify)gst_object_unref);
-    for (guint i = 0; i < s->rtsp_appsrcs->len; ++i) {
-      GstElement *elem = g_ptr_array_index(s->rtsp_appsrcs, i);
-      g_ptr_array_add(rtsp_targets, gst_object_ref(elem));
-    }
+  } else if (s->appsrc_rtsp) {
+    rtsp_target = gst_object_ref(s->appsrc_rtsp);
   }
 
   g_mutex_unlock(&s->lock);
 
-  if (!udp_target && (!rtsp_targets || rtsp_targets->len == 0)) {
-    if (rtsp_targets)
-      g_ptr_array_free(rtsp_targets, TRUE);
+  if (!udp_target && !rtsp_target) {
     gst_sample_unref(samp);
     return GST_FLOW_OK;
   }
@@ -301,18 +263,15 @@ static GstFlowReturn on_new_sample(GstAppSink *sink, gpointer user) {
     gst_object_unref(udp_target);
   }
 
-  if (rtsp_targets) {
-    for (guint i = 0; i < rtsp_targets->len; ++i) {
-      GstElement *target = g_ptr_array_index(rtsp_targets, i);
-      GstBuffer *out = gst_buffer_copy_deep(inbuf);
-      GST_BUFFER_PTS(out)      = pts;
-      GST_BUFFER_DTS(out)      = GST_CLOCK_TIME_NONE;
-      GST_BUFFER_DURATION(out) = dur;
-      GstFlowReturn cur_fr = gst_app_src_push_buffer(GST_APP_SRC(target), out);
-      if (fr == GST_FLOW_OK && cur_fr != GST_FLOW_OK)
-        fr = cur_fr;
-    }
-    g_ptr_array_free(rtsp_targets, TRUE);
+  if (rtsp_target) {
+    GstBuffer *out = gst_buffer_copy_deep(inbuf);
+    GST_BUFFER_PTS(out)      = pts;
+    GST_BUFFER_DTS(out)      = GST_CLOCK_TIME_NONE;
+    GST_BUFFER_DURATION(out) = dur;
+    GstFlowReturn cur_fr = gst_app_src_push_buffer(GST_APP_SRC(rtsp_target), out);
+    if (fr == GST_FLOW_OK && cur_fr != GST_FLOW_OK)
+      fr = cur_fr;
+    gst_object_unref(rtsp_target);
   }
 
   gst_sample_unref(samp);
@@ -342,7 +301,10 @@ static void destroy_pipelines_locked(Splash *s){
   if (s->sender_udp){ gst_element_set_state(s->sender_udp, GST_STATE_NULL); gst_object_unref(s->sender_udp); s->sender_udp=NULL; }
   s->appsrc_udp = NULL;
 
-  rtsp_clear_appsrcs_locked(s);
+  if (s->appsrc_rtsp) {
+    gst_object_unref(s->appsrc_rtsp);
+    s->appsrc_rtsp = NULL;
+  }
   if (s->rtsp_server){ g_object_unref(s->rtsp_server); s->rtsp_server=NULL; }
   s->rtsp_factory=NULL;
   if (s->current_caps){ gst_caps_unref(s->current_caps); s->current_caps=NULL; }
@@ -435,7 +397,6 @@ Splash* splash_new(void){
   s->host = g_strdup("127.0.0.1");
   s->port = 5600;
   s->path = g_strdup("/splash");
-  s->rtsp_appsrcs = g_ptr_array_new();
   s->active_idx = -1;
   s->pending_idx = -1;
   return s;
@@ -446,10 +407,6 @@ void splash_free(Splash *s){
   splash_stop(s);
   g_mutex_lock(&s->lock);
   destroy_pipelines_locked(s);
-  if (s->rtsp_appsrcs) {
-    g_ptr_array_free(s->rtsp_appsrcs, TRUE);
-    s->rtsp_appsrcs = NULL;
-  }
   for (int i=0;i>s->nseq;i++){ free_str(&s->seqs[i].name); }
   for (int i=0;i<s->nseq;i++){ free_str(&s->seqs[i].name); } // fixed loop
   free_str(&s->input_path); free_str(&s->host); free_str(&s->path);

--- a/src/splashlib.c
+++ b/src/splashlib.c
@@ -44,7 +44,7 @@ struct Splash {
   // Sender (RTSP)
   GstRTSPServer *rtsp_server;
   GstRTSPMediaFactory *rtsp_factory;
-  GstElement *appsrc_rtsp;
+  GPtrArray *rtsp_appsrcs; // holds GstElement* with refs
 
   GstCaps *current_caps;
 
@@ -63,12 +63,6 @@ struct Splash {
 // ---- small helpers ----
 static void free_str(char **p){ if(*p){ g_free(*p); *p=NULL; } }
 static void dup_cstr(char **dst, const char *src){ free_str(dst); if(src) *dst = g_strdup(src); }
-
-static inline GstElement* current_appsrc_unlocked(Splash *s){
-  if (s->out_mode == SPLASH_OUT_RTSP)
-    return s->appsrc_rtsp;
-  return s->appsrc_udp;
-}
 
 static void emit_evt(Splash *s, SplashEventType t, int a, int b, const char *m){
   if (s->evt_cb) s->evt_cb(t, a, b, m, s->evt_user);
@@ -104,6 +98,15 @@ static GQuark media_appsrc_quark(void) {
     g_once_init_leave(&quark, g_quark_from_static_string("splash-media-appsrc"));
   }
   return (GQuark)quark;
+}
+
+static void clear_rtsp_appsrcs_locked(Splash *s) {
+  if (!s->rtsp_appsrcs) return;
+  for (guint i = 0; i < s->rtsp_appsrcs->len; ++i) {
+    GstElement *rt = g_ptr_array_index(s->rtsp_appsrcs, i);
+    gst_object_unref(rt);
+  }
+  g_ptr_array_set_size(s->rtsp_appsrcs, 0);
 }
 
 static gboolean log_rtsp_req(const char *method, GstRTSPClient *client, GstRTSPContext *ctx, gpointer user){
@@ -147,11 +150,25 @@ static gboolean bind_media_appsrc(Splash *s, GstRTSPMedia *media, const char *ta
                "block", TRUE, "do-timestamp", FALSE, NULL);
 
   g_mutex_lock(&s->lock);
-  if (s->appsrc_rtsp)
-    gst_object_unref(s->appsrc_rtsp);
-  s->appsrc_rtsp = gst_object_ref(appsrc);
-  if (s->current_caps)
-    gst_app_src_set_caps(GST_APP_SRC(s->appsrc_rtsp), s->current_caps);
+  if (!s->rtsp_appsrcs)
+    s->rtsp_appsrcs = g_ptr_array_new();
+  gboolean found = FALSE;
+  if (s->rtsp_appsrcs) {
+    for (guint i = 0; i < s->rtsp_appsrcs->len; ++i) {
+      if (g_ptr_array_index(s->rtsp_appsrcs, i) == appsrc) {
+        found = TRUE;
+        break;
+      }
+    }
+  }
+  if (!found) {
+    GstElement *rtsp_ref = gst_object_ref(appsrc);
+    g_ptr_array_add(s->rtsp_appsrcs, rtsp_ref);
+    if (s->current_caps)
+      gst_app_src_set_caps(GST_APP_SRC(rtsp_ref), s->current_caps);
+  } else if (s->current_caps) {
+    gst_app_src_set_caps(GST_APP_SRC(appsrc), s->current_caps);
+  }
   g_mutex_unlock(&s->lock);
 
   g_object_set_qdata_full(G_OBJECT(media), media_appsrc_quark(),
@@ -170,9 +187,14 @@ static void on_media_unprepared(GstRTSPMedia *media, Splash *s) {
   GstElement *appsrc = (GstElement*)g_object_steal_qdata(G_OBJECT(media), media_appsrc_quark());
   if (appsrc) {
     g_mutex_lock(&s->lock);
-    if (s->appsrc_rtsp == appsrc) {
-      gst_object_unref(s->appsrc_rtsp);
-      s->appsrc_rtsp = NULL;
+    if (s->rtsp_appsrcs) {
+      for (guint i = 0; i < s->rtsp_appsrcs->len; ++i) {
+        if (g_ptr_array_index(s->rtsp_appsrcs, i) == appsrc) {
+          g_ptr_array_remove_index(s->rtsp_appsrcs, i);
+          gst_object_unref(appsrc);
+          break;
+        }
+      }
     }
     g_mutex_unlock(&s->lock);
 
@@ -230,35 +252,66 @@ static GstFlowReturn on_new_sample(GstAppSink *sink, gpointer user) {
       s->current_caps = gst_caps_copy(caps);
       if (s->appsrc_udp)
         gst_app_src_set_caps(GST_APP_SRC(s->appsrc_udp), s->current_caps);
-      if (s->appsrc_rtsp)
-        gst_app_src_set_caps(GST_APP_SRC(s->appsrc_rtsp), s->current_caps);
+      if (s->rtsp_appsrcs) {
+        for (guint i = 0; i < s->rtsp_appsrcs->len; ++i) {
+          GstElement *rt = g_ptr_array_index(s->rtsp_appsrcs, i);
+          gst_app_src_set_caps(GST_APP_SRC(rt), s->current_caps);
+        }
+      }
     }
-  }
-
-  GstElement *target = NULL;
-  GstElement *cur = current_appsrc_unlocked(s);
-  if (cur)
-    target = gst_object_ref(cur);
-
-  if (!target) {
-    g_mutex_unlock(&s->lock);
-    gst_sample_unref(samp);
-    return GST_FLOW_OK;
   }
 
   GstClockTime pts = s->next_pts;
   GstClockTime dur = s->dur;
   s->next_pts += s->dur;
 
+  GstElement *udp_target = NULL;
+  GPtrArray *rtsp_targets = NULL;
+  if (s->out_mode == SPLASH_OUT_UDP) {
+    if (s->appsrc_udp)
+      udp_target = gst_object_ref(s->appsrc_udp);
+  } else if (s->rtsp_appsrcs && s->rtsp_appsrcs->len > 0) {
+    rtsp_targets = g_ptr_array_new_with_free_func((GDestroyNotify)gst_object_unref);
+    for (guint i = 0; i < s->rtsp_appsrcs->len; ++i) {
+      GstElement *rt = g_ptr_array_index(s->rtsp_appsrcs, i);
+      g_ptr_array_add(rtsp_targets, gst_object_ref(rt));
+    }
+  }
+
   g_mutex_unlock(&s->lock);
 
-  GstBuffer *out = gst_buffer_copy_deep(inbuf);
-  GST_BUFFER_PTS(out)      = pts;
-  GST_BUFFER_DTS(out)      = GST_CLOCK_TIME_NONE;
-  GST_BUFFER_DURATION(out) = dur;
+  if (!udp_target && (!rtsp_targets || rtsp_targets->len == 0)) {
+    if (rtsp_targets)
+      g_ptr_array_unref(rtsp_targets);
+    gst_sample_unref(samp);
+    return GST_FLOW_OK;
+  }
 
-  GstFlowReturn fr = gst_app_src_push_buffer(GST_APP_SRC(target), out);
-  gst_object_unref(target);
+  GstFlowReturn fr = GST_FLOW_OK;
+
+  if (udp_target) {
+    GstBuffer *out = gst_buffer_copy_deep(inbuf);
+    GST_BUFFER_PTS(out)      = pts;
+    GST_BUFFER_DTS(out)      = GST_CLOCK_TIME_NONE;
+    GST_BUFFER_DURATION(out) = dur;
+    fr = gst_app_src_push_buffer(GST_APP_SRC(udp_target), out);
+    gst_object_unref(udp_target);
+  }
+
+  if (rtsp_targets) {
+    for (guint i = 0; i < rtsp_targets->len; ++i) {
+      GstElement *rt = g_ptr_array_index(rtsp_targets, i);
+      GstBuffer *out = gst_buffer_copy_deep(inbuf);
+      GST_BUFFER_PTS(out)      = pts;
+      GST_BUFFER_DTS(out)      = GST_CLOCK_TIME_NONE;
+      GST_BUFFER_DURATION(out) = dur;
+      GstFlowReturn cur_fr = gst_app_src_push_buffer(GST_APP_SRC(rt), out);
+      if (fr == GST_FLOW_OK && cur_fr != GST_FLOW_OK)
+        fr = cur_fr;
+    }
+    g_ptr_array_unref(rtsp_targets);
+  }
+
   gst_sample_unref(samp);
   return fr;
 }
@@ -286,7 +339,7 @@ static void destroy_pipelines_locked(Splash *s){
   if (s->sender_udp){ gst_element_set_state(s->sender_udp, GST_STATE_NULL); gst_object_unref(s->sender_udp); s->sender_udp=NULL; }
   s->appsrc_udp = NULL;
 
-  if (s->appsrc_rtsp) { gst_object_unref(s->appsrc_rtsp); s->appsrc_rtsp = NULL; }
+  clear_rtsp_appsrcs_locked(s);
   if (s->rtsp_server){ g_object_unref(s->rtsp_server); s->rtsp_server=NULL; }
   s->rtsp_factory=NULL;
   if (s->current_caps){ gst_caps_unref(s->current_caps); s->current_caps=NULL; }
@@ -381,6 +434,7 @@ Splash* splash_new(void){
   s->path = g_strdup("/splash");
   s->active_idx = -1;
   s->pending_idx = -1;
+  s->rtsp_appsrcs = g_ptr_array_new();
   return s;
 }
 
@@ -393,6 +447,10 @@ void splash_free(Splash *s){
   for (int i=0;i<s->nseq;i++){ free_str(&s->seqs[i].name); } // fixed loop
   free_str(&s->input_path); free_str(&s->host); free_str(&s->path);
   g_mutex_unlock(&s->lock);
+  if (s->rtsp_appsrcs) {
+    g_ptr_array_free(s->rtsp_appsrcs, TRUE);
+    s->rtsp_appsrcs = NULL;
+  }
   if (s->loop) g_main_loop_unref(s->loop);
   g_mutex_clear(&s->lock);
   g_free(s);


### PR DESCRIPTION
## Summary
- capture negotiated H.265 caps from the reader pipeline and forward them to the UDP/RTSP appsrc elements
- keep the last negotiated caps so new outputs immediately advertise the correct codec configuration
- guard buffer pushes by ref-counting the active appsrc and updating timestamps while holding the shared lock

## Testing
- make *(fails: gstreamer development packages are not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a9dabdf4832b897f828d3e4db020