### PR TITLE
Remove RTSP streaming support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile (outputs in current dir; sources in ./src)
 
 # --- Config ---
-PKGS := gstreamer-1.0 gstreamer-app-1.0 gstreamer-rtsp-server-1.0
+PKGS := gstreamer-1.0 gstreamer-app-1.0
 CC   ?= gcc
 
 CFLAGS  ?= -O2 -fPIC $(shell pkg-config --cflags $(PKGS)) -Isrc
@@ -15,7 +15,7 @@ OBJDIR   := build
 LIB_OBJS := $(OBJDIR)/splashlib.o
 
 # --- Phony targets ---
-.PHONY: all clean static run-udp run-rtsp
+.PHONY: all clean static run-udp
 
 # Default: shared lib + app linked against it
 all: $(LIB) $(APP)
@@ -42,9 +42,6 @@ $(OBJDIR):
 # Convenience run targets (adjust args as needed)
 run-udp: $(APP)
 	./$(APP) spinner_1080p30.h265 30 --udp 127.0.0.1 5600
-
-run-rtsp: $(APP)
-	./$(APP) spinner_1080p30.h265 30 --rtsp 0.0.0.0 8554 /splash
 
 # Cleanup
 clean:

--- a/src/splashlib.h
+++ b/src/splashlib.h
@@ -11,12 +11,6 @@ extern "C" {
 // Opaque handle
 typedef struct Splash Splash;
 
-// Output mode
-typedef enum {
-  SPLASH_OUT_UDP = 0,
-  SPLASH_OUT_RTSP = 1
-} SplashOutMode;
-
 // Named sequence: inclusive frame indices [start..end]
 typedef struct {
   const char *name;   // non-owning utf8 string
@@ -24,19 +18,17 @@ typedef struct {
   int end_frame;      // e.g., 180
 } SplashSeq;
 
-// UDP / RTSP endpoints
+// UDP endpoint
 typedef struct {
   const char *host;  // e.g., "127.0.0.1"
-  int port;          // e.g., 5600 or 8554
-  const char *path;  // RTSP only, e.g., "/splash"
+  int port;          // e.g., 5600
 } SplashEndpoint;
 
 // Configuration
 typedef struct {
   const char *input_path;   // Annex-B H.265 elementary stream (AUD+VUI recommended)
   double fps;               // e.g., 30.0
-  SplashOutMode out_mode;   // UDP or RTSP
-  SplashEndpoint endpoint;  // UDP: host+port; RTSP: host+port+path
+  SplashEndpoint endpoint;  // UDP host+port
 } SplashConfig;
 
 // Event callback (optional)


### PR DESCRIPTION
## Summary
- drop the RTSP build dependency and sample target from the Makefile
- simplify the CLI and configuration structures to only support UDP output
- strip the RTSP server pipeline code paths and keep the UDP sender intact

## Testing
- make *(fails: gstreamer-1.0 and gstreamer-app-1.0 dev packages not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c0ab71e4832b89f2c1e86afa19fb