### PR TITLE
Ensure make extracts demo asset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,18 +7,23 @@ CC   ?= gcc
 CFLAGS  ?= -O2 -fPIC $(shell pkg-config --cflags $(PKGS)) -Isrc
 LDFLAGS ?= $(shell pkg-config --libs $(PKGS))
 
-APP      := splash_main
-LIB      := libsplashscreen.so
-OBJDIR   := build
+APP        := splash_main
+LIB        := libsplashscreen.so
+OBJDIR     := build
+
+ASSET_ZIP := spinner_ai_1080p30.zip
+ASSET_OUT := $(ASSET_ZIP:.zip=.h265)
 
 # Objects
 LIB_OBJS := $(OBJDIR)/splashlib.o
 
 # --- Phony targets ---
-.PHONY: all clean static run-udp
+.PHONY: all assets clean static run-udp
 
 # Default: shared lib + app linked against it
-all: $(LIB) $(APP)
+all: assets $(LIB) $(APP)
+
+assets: $(ASSET_OUT)
 
 # Shared library
 $(LIB): $(LIB_OBJS)
@@ -39,10 +44,14 @@ $(OBJDIR)/%.o: src/%.c src/%.h | $(OBJDIR)
 $(OBJDIR):
 	@mkdir -p $(OBJDIR)
 
+$(ASSET_OUT): $(ASSET_ZIP)
+	@echo "Unpacking $<"
+	unzip -o $< $(ASSET_OUT)
+
 # Convenience run targets (adjust args as needed)
 run-udp: $(APP)
 	./$(APP) config/demo.ini
 
 # Cleanup
 clean:
-	rm -rf $(OBJDIR) $(APP) $(LIB)
+	rm -rf $(OBJDIR) $(APP) $(LIB) $(ASSET_OUT)

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ $(OBJDIR):
 
 $(ASSET_OUT): $(ASSET_ZIP)
 	@echo "Unpacking $<"
-	unzip -o $< $(ASSET_OUT)
+	python3 -c "import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extract(sys.argv[2])" $< $(ASSET_OUT)
 
 # Convenience run targets (adjust args as needed)
 run-udp: $(APP)

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ $(OBJDIR):
 
 $(ASSET_OUT): $(ASSET_ZIP)
 	@echo "Unpacking $<"
-	python3 -c "import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extract(sys.argv[2])" $< $(ASSET_OUT)
+	gunzip -c $< > $@
 
 # Convenience run targets (adjust args as needed)
 run-udp: $(APP)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ sudo apt-get install -y \
 
 Once the dependencies are present, build the project with `make`. The default
 rule compiles the CLI and HTTP control application as well as the supporting
-`splashlib` GStreamer wrapper.
+`splashlib` GStreamer wrapper. The build also unpacks the demo
+`spinner_ai_1080p30.h265` stream from the checked-in ZIP archive so the sample
+configuration can run immediately.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ predefined combo playlists.
 
 ## Requirements
 
-Install the development toolchain and GStreamer components before building.
-Python 3 is also required so the build can extract the bundled demo asset:
+Install the development toolchain, GStreamer components, and GNU gzip before
+building so the asset extraction rule can unpack the bundled demo stream:
 
 ```sh
 sudo apt-get update
@@ -16,7 +16,8 @@ sudo apt-get install -y \
   build-essential pkg-config \
   libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
   libgstrtspserver-1.0-dev \
-  gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly
+  gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
+  gzip
 ```
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ predefined combo playlists.
 
 ## Requirements
 
-Install the development toolchain and GStreamer components before building:
+Install the development toolchain and GStreamer components before building.
+Python 3 is also required so the build can extract the bundled demo asset:
 
 ```sh
 sudo apt-get update


### PR DESCRIPTION
## Summary
- add an asset extraction rule so `make` also unpacks the spinner H.265 demo stream
- document that the build now unpacks the demo asset automatically

## Testing
- make assets
- make clean
- make

------
https://chatgpt.com/codex/tasks/task_e_68e13b7b06c8832b8c7a8f52f973f79b