### PR TITLE
Implement UDP failover monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ illustrates every available section:
   - `fps`: Frame rate of the input material (double).
   - `host`: Destination IP for the RTP/UDP output.
   - `port`: Destination UDP port.
+  - `secondary_host`: Optional destination IP for a standby output. Defaults to
+    `host` when omitted but `secondary_port` is provided.
+  - `secondary_port`: Optional fallback UDP port. When configured, the primary
+    `port` remains active while traffic is present; packets on the secondary
+    port are discarded until the primary stream falls silent, at which point the
+    secondary output is enabled automatically.
 - `[control]`
   - `port`: HTTP control port (defaults to `8081` if omitted).
   - `combo_loop_mode`: Controls how combo playlists repeat once the queue drains.
@@ -62,6 +68,13 @@ When CLI mode is enabled (`--cli`), press `1-9` to enqueue individual sequences,
 `c` to clear the queue, `s` to start, `x` to stop, and `q` to quit. All control
 features are also available over HTTP via `GET /request/{start,stop,list}` and
 `GET /request/enqueue/<name>` for sequences or combos.
+
+The runtime monitors the configured UDP ports to provide seamless failover. As
+long as datagrams are observed on the primary port, the program streams only to
+that destination and ignores the secondary port to avoid unnecessary CPU load.
+If the primary stream stops for a brief period, the secondary socket is enabled
+and the application automatically switches its UDP output to the secondary
+destination as soon as packets arrive there.
 
 ## Preparing H.265 Inputs
 

--- a/config/demo.ini
+++ b/config/demo.ini
@@ -3,6 +3,8 @@ input=../spinner_ai_1080p30.h265
 fps=30.0
 host=127.0.0.1
 port=5600
+;secondary_host=127.0.0.1
+;secondary_port=5601
 
 [control]
 port=8081

--- a/src/main.c
+++ b/src/main.c
@@ -398,7 +398,7 @@ static GSocket *create_udp_probe_socket(guint16 port){
   g_socket_set_blocking(sock, FALSE);
   GInetAddress *addr = g_inet_address_new_any(G_SOCKET_FAMILY_IPV4);
   GSocketAddress *saddr = g_inet_socket_address_new(addr, port);
-  g_inet_address_unref(addr);
+  g_object_unref(addr);
   if (!g_socket_bind(sock, saddr, TRUE, &error)){
     fprintf(stderr, "[failover] unable to bind UDP probe on port %u: %s\n",
             port, error ? error->message : "unknown error");

--- a/src/splashlib.h
+++ b/src/splashlib.h
@@ -29,6 +29,7 @@ typedef struct {
   const char *input_path;   // Annex-B H.265 elementary stream (AUD+VUI recommended)
   double fps;               // e.g., 30.0
   SplashEndpoint endpoint;  // UDP host+port
+  SplashEndpoint secondary_endpoint;  // optional secondary UDP host+port (port<=0 disables)
 } SplashConfig;
 
 // Event callback (optional)
@@ -96,6 +97,9 @@ int  splash_find_index_by_name(Splash *s, const char *name);
 
 // Logging / events
 void splash_set_event_cb(Splash *s, SplashEventCb cb, void *user);
+
+// Runtime control helpers
+void splash_select_endpoint(Splash *s, gboolean use_secondary);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- add optional secondary UDP endpoint configuration and documentation
- monitor primary/secondary UDP traffic to prefer the main port and drop standby data until failover is required
- update the streaming library to manage dual senders and expose a selection API used by the runtime

## Testing
- make *(fails: gstreamer development packages are unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e14d46affc832b9e3f82095b269d3d