### PR TITLE
Add configurable appsrc output to splashlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,13 @@ illustrates every available section:
   - `input`: Path to an H.265 elementary stream file that contains repeated key
     frames.
   - `fps`: Frame rate of the input material (double).
-  - `host`: Destination IP for the RTP/UDP output.
-  - `port`: Destination UDP port.
+  - `outputs`: Optional comma-separated list of `udp` and/or `appsrc` outputs.
+    The default is `udp`. When `appsrc` is enabled the library exposes a
+    timestamped `GstAppSrc` via `splash_get_appsrc()` for applications that want
+    to feed the frames into their own pipelines.
+  - `host`: Destination IP for the RTP/UDP output (required when `udp` is
+    enabled).
+  - `port`: Destination UDP port (required when `udp` is enabled).
 - `[control]`
   - `port`: HTTP control port (defaults to `8081` if omitted).
   - `combo_loop_mode`: Controls how combo playlists repeat once the queue drains.
@@ -91,6 +96,15 @@ Splashscreen RK.
 - `GET /request/enqueue/<name>` — enqueue either a single sequence or a combo by
   name. When combos marked with `loop_at_end=true` are enqueued, they will
   repeat according to `combo_loop_mode` until the queue is updated.
+
+## Library Appsrc Output
+
+Projects embedding `splashlib` can request a direct application source instead
+of, or in addition to, the UDP sender. Set `stream.outputs=appsrc` (or
+`stream.outputs=udp,appsrc`) in the configuration and call
+`splash_get_appsrc()` to obtain a referenced `GstElement*`. The returned element
+is configured as live H.265 output using the configured framerate so it can be
+added to custom pipelines.
 
 ## License
 

--- a/config/demo.ini
+++ b/config/demo.ini
@@ -1,6 +1,7 @@
 [stream]
 input=../spinner_ai_1080p30.h265
 fps=30.0
+;outputs=udp,appsrc
 host=127.0.0.1
 port=5600
 

--- a/src/splashlib.h
+++ b/src/splashlib.h
@@ -18,6 +18,13 @@ typedef struct {
   int end_frame;      // e.g., 180
 } SplashSeq;
 
+// Output selection
+typedef enum {
+  SPLASH_OUTPUT_NONE   = 0,
+  SPLASH_OUTPUT_UDP    = 1 << 0,
+  SPLASH_OUTPUT_APPSRC = 1 << 1,
+} SplashOutputMode;
+
 // UDP endpoint
 typedef struct {
   const char *host;  // e.g., "127.0.0.1"
@@ -28,6 +35,7 @@ typedef struct {
 typedef struct {
   const char *input_path;   // Annex-B H.265 elementary stream (AUD+VUI recommended)
   double fps;               // e.g., 30.0
+  SplashOutputMode outputs; // Bitmask of SPLASH_OUTPUT_* values (defaults to UDP)
   SplashEndpoint endpoint;  // UDP host+port
 } SplashConfig;
 
@@ -96,6 +104,9 @@ int  splash_find_index_by_name(Splash *s, const char *name);
 
 // Logging / events
 void splash_set_event_cb(Splash *s, SplashEventCb cb, void *user);
+
+// Accessors for optional outputs
+GstElement* splash_get_appsrc(Splash *s); // returns new ref or NULL when disabled
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- add a new SplashOutputMode bitmask so splashlib can be configured for UDP, appsrc, or both outputs
- expose splash_get_appsrc() and update the sample pipeline to push frames to every enabled output
- extend the INI parser, sample config, and README to document the new stream.outputs option

## Testing
- make *(fails: missing GStreamer development packages in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b7f7eea0832bbc60934925f1544c